### PR TITLE
Added timeout to TMI client joining channels in attempt to fix not joining all channels

### DIFF
--- a/twitch/twitch.js
+++ b/twitch/twitch.js
@@ -1,5 +1,6 @@
 const CLIENT_CONNECT_TIMEOUT = 5000;
 const CLIENT_MAXIMUM_CHANNELS = 15;
+const CHANNEL_CONNECT_INTERVAL = 500;
 
 const ACTIVE_CHANNEL_PADDING = 3;
 
@@ -562,7 +563,9 @@ const initializeClient = () => {
                 };
         
                 clientObj.channels.forEach(channel => {
-                    client.join(channel).catch(console.error);
+                    setTimeout(() => {
+                        client.join(channel).catch(console.error);
+                    }, CHANNEL_CONNECT_INTERVAL)
                 });
 
                 clientObj.status = "initialized";

--- a/twitch/twitch.js
+++ b/twitch/twitch.js
@@ -561,12 +561,6 @@ const initializeClient = () => {
                         client.join(name);
                     }
                 };
-        
-                for (let i = 0; i < clientObj.channels.length; i++) {
-                    setTimeout(() => {
-                        client.join(clientObj.channels[i]).catch(console.error)
-                    }, i * CLIENT_CONNECT_TIMEOUT);
-                }
 
                 clientObj.channels.forEach(channel => {
                     setTimeout(() => {

--- a/twitch/twitch.js
+++ b/twitch/twitch.js
@@ -562,10 +562,16 @@ const initializeClient = () => {
                     }
                 };
         
+                for (let i = 0; i < clientObj.channels.length; i++) {
+                    setTimeout(() => {
+                        client.join(clientObj.channels[i]).catch(console.error)
+                    }, i * CLIENT_CONNECT_TIMEOUT);
+                }
+
                 clientObj.channels.forEach(channel => {
                     setTimeout(() => {
                         client.join(channel).catch(console.error);
-                    }, CHANNEL_CONNECT_INTERVAL)
+                    }, clientObj.channels.indexOf(channel) * CHANNEL_CONNECT_INTERVAL)
                 });
 
                 clientObj.status = "initialized";

--- a/twitch/twitch.js
+++ b/twitch/twitch.js
@@ -649,7 +649,9 @@ con.query("select distinct lower(twitch__user.display_name) as name from identit
     if (err) {console.error(err);return;}
 
     res.forEach(streamer => {
-        listenOnChannel(streamer.name);
+        setTimeout(() => {
+            listenOnChannel(streamer.name);
+        }, res.indexOf(streamer) * CHANNEL_CONNECT_INTERVAL)
     });
 
     setTimeout(() => {


### PR DESCRIPTION
<html><body>
<!--StartFragment-->

joinInterval | number | 2000 | Controls the delay in milliseconds between JOIN requests when using the channels array 								option. Minimum of 300 milliseconds. If the identity has special permission from Twitch 								for a higher join rate then you should implement your own calls to the 								client.join method.
-- | -- | -- | --


<!--EndFragment-->
</body>
</html>

- Updating the twitch.js channel join loop to account for the 300ms minimum delay.
- CHANNEL_CONNECT_INTERVAL set to 500 just to be safe for now